### PR TITLE
01.07. 패치

### DIFF
--- a/FindingAlice/Assets/Prefabs/Item_Clock.prefab
+++ b/FindingAlice/Assets/Prefabs/Item_Clock.prefab
@@ -109,6 +109,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2e019aa3b893be4d92565b531ea7c42, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  childObject: {fileID: 2858474603737465532}
 --- !u!1001 &3128381405540810733
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -193,6 +194,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5bf57dd75bf64c548811b3cd74b93d26, type: 3}
+--- !u!1 &2858474603737465532 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 5bf57dd75bf64c548811b3cd74b93d26,
+    type: 3}
+  m_PrefabInstance: {fileID: 3128381405540810733}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &3233733160895191046 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 5bf57dd75bf64c548811b3cd74b93d26,

--- a/FindingAlice/Assets/_Scripts/Item_Clock.cs
+++ b/FindingAlice/Assets/_Scripts/Item_Clock.cs
@@ -5,15 +5,22 @@ using UnityEngine;
 public class Item_Clock : MonoBehaviour
 {
     float collidedTime = 0f;
-    float appearTime = 3f;
+    float appearTime = 3.0f;
+
+    [SerializeField] GameObject childObject;
+    Collider collider;
+
+    private void Awake()
+    {
+        collider = gameObject.GetComponent<Collider>();
+    }
 
     private void OnTriggerEnter(Collider other)
     {
 
         if (other.tag == "Player")
-        {   
-            Invoke("respawn", 3f);
-            gameObject.SetActive(false);
+        {
+            StartCoroutine(ReSpawn());
 
             if (ClockManager.C.clockCounter < 2)
             {
@@ -24,8 +31,13 @@ public class Item_Clock : MonoBehaviour
         }
     }
 
-    void respawn()
+    IEnumerator ReSpawn()
     {
-        gameObject.SetActive(true);
+        childObject.SetActive(false);
+        collider.enabled = false;
+        yield return new WaitForSeconds(appearTime);
+
+        childObject.SetActive(true);
+        collider.enabled = true;
     }
 }


### PR DESCRIPTION
-챕터 1 일부 레벨 지형 및 난이도 조정
-챕터 1에서 과도하게 존재하던 시계 아이템 일부 제거
(너무 난잡하고, 레벨 디자인의 완성도를 떨어트려 제거됨)
-Item_Clock 스크립트가 다음과 같은 이유로 변경됩니다.
->Invoke보다 더 성능이 좋은 코루틴 함수를 사용하도록 변경
->Transparent 오브젝트로 해당 스크립트를 사용하는 오브젝트를 Setactive(false)로 할 때 false로 되지 않는 문제가 생겨 부모의 Collider와 자식의 GameObject를 이용하도록 변경